### PR TITLE
fix the zip.js error in cesium 1.85

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vuex": "^3.6.2"
   },
   "devDependencies": {
+    "@open-wc/webpack-import-meta-loader": "^0.4.7",
     "@types/cesium": "^1.67.14",
     "@vue/cli-plugin-babel": "^4.5.13",
     "@vue/cli-plugin-eslint": "^4.5.13",

--- a/vue.config.js
+++ b/vue.config.js
@@ -58,6 +58,9 @@ module.exports = {
             }
           }
         }]
+      },{
+        test: /\.js$/,
+        use: { loader: require.resolve('@open-wc/webpack-import-meta-loader') }
       }]
     }
   },


### PR DESCRIPTION
Issues: https://github.com/meschg/vue-stack-cesium/issues/6

Describe:
1. add `@open-wc/webpack-import-meta-loader`
2. modify vue.config.js `config.module.rules`